### PR TITLE
New Package expect-shallow-snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Utility functions to make testing React/Redux applications with Jest easier.
 
 For details, see each of the test utilities:
 
-* **expect-snapshot**: [readme](packages/expect-snapshot/README.md) / [changelog](packages/expect-snapshot/CHANGELOG.md)
-* **mock-store**: [readme](packages/mock-store/README.md) / [changelog](packages/mock-store/CHANGELOG.md)
-* **mount-hoc**: [readme](packages/mount-hoc/README.md) / [changelog](packages/mount-hoc/CHANGELOG.md)
-* **test-saga**: [readme](packages/test-saga/README.md) / [changelog](packages/test-saga/CHANGELOG.md)
+*   **expect-snapshot**: [readme](packages/expect-snapshot/README.md) / [changelog](packages/expect-snapshot/CHANGELOG.md)
+*   **expect-shallow-snapshot**: [readme](packages/expect-shallow-snapshot/README.md) / [changelog](packages/expect-shallow-snapshot/CHANGELOG.md)
+*   **mock-store**: [readme](packages/mock-store/README.md) / [changelog](packages/mock-store/CHANGELOG.md)
+*   **mount-hoc**: [readme](packages/mount-hoc/README.md) / [changelog](packages/mount-hoc/CHANGELOG.md)
+*   **test-saga**: [readme](packages/test-saga/README.md) / [changelog](packages/test-saga/CHANGELOG.md)
 
-For tipps on how to maintain this repository, see the [contribution guidelines](CONTRIBUTING.md).
+For tips on how to maintain this repository, see the [contribution guidelines](CONTRIBUTING.md).
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,10 +2662,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4618,8 +4617,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
-      "dev": true
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -7828,12 +7826,11 @@
       }
     },
     "rc": {
-      "version": "1.2.5",
-      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/rc/-/rc-1.2.5.tgz",
-      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
-      "dev": true,
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "~0.4.0",
+        "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
@@ -7841,9 +7838,8 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -9269,8 +9265,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "strong-log-transformer": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -619,6 +619,17 @@
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
     },
+    "array.prototype.flat": {
+      "version": "1.2.1",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+      "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.10.0",
+        "function-bind": "^1.1.1"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/arrify/-/arrify-1.0.1.tgz",
@@ -2915,27 +2926,47 @@
       "dev": true
     },
     "enzyme": {
-      "version": "3.3.0",
-      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/enzyme/-/enzyme-3.3.0.tgz",
-      "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
+      "version": "3.7.0",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/enzyme/-/enzyme-3.7.0.tgz",
+      "integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
       "dev": true,
       "requires": {
+        "array.prototype.flat": "^1.2.1",
         "cheerio": "^1.0.0-rc.2",
-        "function.prototype.name": "^1.0.3",
-        "has": "^1.0.1",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
         "is-boolean-object": "^1.0.0",
-        "is-callable": "^1.1.3",
+        "is-callable": "^1.1.4",
         "is-number-object": "^1.0.3",
         "is-string": "^1.0.4",
         "is-subset": "^0.1.1",
-        "lodash": "^4.17.4",
-        "object-inspect": "^1.5.0",
+        "lodash.escape": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "object-inspect": "^1.6.0",
         "object-is": "^1.0.1",
         "object.assign": "^4.1.0",
         "object.entries": "^1.0.4",
         "object.values": "^1.0.4",
         "raf": "^3.4.0",
-        "rst-selector-parser": "^2.2.3"
+        "rst-selector-parser": "^2.2.3",
+        "string.prototype.trim": "^1.1.2"
+      },
+      "dependencies": {
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+          "dev": true
+        }
       }
     },
     "enzyme-adapter-react-16": {
@@ -6500,6 +6531,12 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6510,6 +6547,12 @@
       "version": "4.4.2",
       "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.sortby": {
@@ -6864,6 +6907,12 @@
       "integrity": "sha1-1usaRsvMFKKy+UNBEsH/iQfzE/0=",
       "dev": true
     },
+    "moo": {
+      "version": "0.4.3",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/moo/-/moo-0.4.3.tgz",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -6929,11 +6978,12 @@
       "dev": true
     },
     "nearley": {
-      "version": "2.11.1",
-      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/nearley/-/nearley-2.11.1.tgz",
-      "integrity": "sha512-1azpqq1JvHKZNPEixS1jNEXf4kDilhFtr8AIZIGjP8N0TcAcUhKgi354niI5pM4JoOsMQ+H6vzCYWQa95LQjcw==",
+      "version": "2.15.1",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/nearley/-/nearley-2.15.1.tgz",
+      "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
       "dev": true,
       "requires": {
+        "moo": "^0.4.3",
         "nomnom": "~1.6.2",
         "railroad-diagrams": "^1.0.0",
         "randexp": "0.4.6",
@@ -7106,9 +7156,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.5.0",
-      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/object-inspect/-/object-inspect-1.5.0.tgz",
-      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+      "version": "1.6.0",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-is": {
@@ -9145,6 +9195,17 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-enzyme": "^1.0.0-beta.0",
     "cheerio": "^1.0.0-rc.2",
-    "enzyme": "^3.3.0",
+    "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.1",
     "eslint": "^4.17.0",

--- a/packages/expect-shallow-snapshot/CHANGELOG.md
+++ b/packages/expect-shallow-snapshot/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 1.0.0 / 8 Oct 2018
+
+* Initial release
+

--- a/packages/expect-shallow-snapshot/LICENSE
+++ b/packages/expect-shallow-snapshot/LICENSE
@@ -1,0 +1,19 @@
+Copyright © 2018 mobile.de GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/expect-shallow-snapshot/README.md
+++ b/packages/expect-shallow-snapshot/README.md
@@ -1,0 +1,33 @@
+# expect-shallow-snapshot
+
+This is a convencience function for shallow-rendering a React component and asserting that it matches a Jest snapshot.
+
+Shallow rendering means that nested components are not actually rendered, but show up in the snapshots as 
+React components.
+
+## Installation
+
+    npm install --save-dev @mt-testutils/expect-shallow-snapshot
+
+## Usage
+
+    import MyReactComponent from './MyReactComponent';
+    import expectShallowSnapshot from '@mt-testutils/expect-shallow-snapshot';
+   
+    describe('My react component', () => 
+        it('renders correctly', () => expectShallowSnapshot(<MyComponent />)
+    );
+   
+## Change Log
+
+* See [CHANGELOG.md](CHANGELOG.md)
+
+## Contribution Guidelines
+
+* See [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+## License
+
+[MIT licensed](LICENSE)
+
+Copyright © 2018 mobile.de GmbH

--- a/packages/expect-shallow-snapshot/index.js
+++ b/packages/expect-shallow-snapshot/index.js
@@ -1,0 +1,1 @@
+export { default } from './src/expectShallowSnapshot';

--- a/packages/expect-shallow-snapshot/package.json
+++ b/packages/expect-shallow-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mt-testutils/expect-shallow-snapshot",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Testing utility function to assert that a shallow-rendered React component matches a Jest snapshot",
   "main": "index.js",
   "scripts": {

--- a/packages/expect-shallow-snapshot/package.json
+++ b/packages/expect-shallow-snapshot/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@mt-testutils/expect-shallow-snapshot",
+  "version": "0.0.0",
+  "description": "Testing utility function to assert that a shallow-rendered React component matches a Jest snapshot",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "author": "Patrick Hund <pahund@team.mobile.de> (https://ebaytech.berlin/)",
+  "contributors": [
+    "Ninja Maaß <jmaass@team.mobile.de>",
+    "Daniel Schäfer <danschaefer@team.mobile.de>"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "enzyme": "*"
+  }
+}

--- a/packages/expect-shallow-snapshot/src/__snapshots__/expectShallowSnapshot.test.js.snap
+++ b/packages/expect-shallow-snapshot/src/__snapshots__/expectShallowSnapshot.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`My mock component renders correctly 1`] = `
+<div>
+  test
+</div>
+`;

--- a/packages/expect-shallow-snapshot/src/expectShallowSnapshot.js
+++ b/packages/expect-shallow-snapshot/src/expectShallowSnapshot.js
@@ -1,0 +1,4 @@
+/* global expect */
+
+import { shallow } from 'enzyme';
+export default component => expect(shallow(component).getElement()).toMatchSnapshot();

--- a/packages/expect-shallow-snapshot/src/expectShallowSnapshot.test.js
+++ b/packages/expect-shallow-snapshot/src/expectShallowSnapshot.test.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import expectShallowSnapshot from './expectShallowSnapshot';
+
+const mockComponent = <div>test</div>;
+
+describe('My mock component', () => it('renders correctly', () => expectShallowSnapshot(mockComponent)));

--- a/packages/mount-hoc/package.json
+++ b/packages/mount-hoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mt-testutils/mount-hoc",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A helper function for Jest unit tests that creates higher-order components",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Made an additional version of `expect-snapshot` that uses Enzyme's shallow rendering, this makes snapshot tests more convenient. With the old `expect-snapshot` your would either have to mock child components within the component under test, or have snapshot tests that fail when child components change.